### PR TITLE
Compare SA and SB, instead of SA and itself

### DIFF
--- a/test/sm9test.c
+++ b/test/sm9test.c
@@ -356,7 +356,7 @@ static int sm9test_exch(const char *idA, const char *idB)
 		goto end;
 	}
 
-	if (memcmp(SKA, SKA, sizeof(SKA)) != 0 || memcmp(SA, S2, sizeof(SA)) != 0) {
+	if (memcmp(SKA, SKB, sizeof(SKA)) != 0 || memcmp(SA, S2, sizeof(SA)) != 0) {
 		goto end;
 	}
 


### PR DESCRIPTION
相关Issue：[sm9test.c 中密钥协商的测试函数里，判断条件是否有误?](https://github.com/guanzhi/GmSSL/issues/853)